### PR TITLE
タスク新規登録機能

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,4 +17,10 @@ class TasksController < ApplicationController
 
   def edit
   end
+
+  private
+  
+  def task_params
+    params.require(:task).permit(:name, :description)
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,6 +9,12 @@ class TasksController < ApplicationController
     @task = Task.new
   end
 
+  def create
+    task = Task.new(task_params)
+    task.save!
+    redirect_to tasks_url, notice: "タスクを登録しました。"
+  end
+
   def edit
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,6 +6,7 @@ class TasksController < ApplicationController
   end
 
   def new
+    @task = Task.new
   end
 
   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,7 +12,7 @@ class TasksController < ApplicationController
   def create
     task = Task.new(task_params)
     task.save!
-    redirect_to tasks_url, notice: "タスクを登録しました。"
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
   end
 
   def edit

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,4 +11,6 @@ html
     .app-title.navbar.navbar-expand-md.navbar-light.bg-light
       .navbar-brand Taskleaf
     .container
+      - if flash.notice.present?
+        .alert.alert-success = flash.notice
       = yield

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,2 +1,3 @@
-h1 Tasks#index
-p Find me in app/views/tasks/index.html.slim
+h1 タスク一覧
+
+= link_to "新規登録", new_task_path, class: 'btn btn-primary'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,2 +1,14 @@
-h1 Tasks#new
-p Find me in app/views/tasks/new.html.slim
+h1 タスクの新規登録
+
+.nav.justify-cintent-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+
+  = f.submit nil, class: 'btn btn-primary' 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      task: タスク
+    attributes:
+      task:
+        id: ID
+        name: 名称
+        description: 詳しい説明
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
## What
タスクの新規登録機能を実装する。

## Why
ユーザーに新しいタスクを入力してもらうため。

実装について
- index.html.slimに新規登録ボタンを追加。
- config/localにja.ymlファイルを作成、内容追加。
- tasks_controller.rb内にnewアクションの内容を記述。
- new.html.slimに新規登録入力フォームを記述。
- tasks_controller.rbにcreateアクションと内容を記述。
- tasks_controller.rbにストロングパラメーターを設定。
- フラッシュメッセージの共通表示をapplication.html.slimに追加。