### PR TITLE
タスク詳細表示機能

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,18 +1,18 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = Task.all #タスク情報全てをindexへ表示
   end
 
   def show
-    @task = Task.find(params[:id])
+    @task = Task.find(params[:id]) #各タスクに応じた情報をshowへ表示
   end
 
   def new
-    @task = Task.new
+    @task = Task.new #タスク情報を入力するnewを表示
   end
 
   def create
-    task = Task.new(task_params)
+    task = Task.new(task_params) #newで入力したタスクをテーブルへ保存する
     task.save!
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。" #登録後トップページへリダイレクト
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,7 @@ class TasksController < ApplicationController
   end
 
   def show
+    @task = Task.find(params[:id])
   end
 
   def new

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -17,5 +17,5 @@ table.table.table-hover
     tbody
       - @tasks.each do |task|
         tr
-          td = task.name
+          td = link_to task.name, task_path(task)
           td = task.created_at

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -1,2 +1,28 @@
-h1 Tasks#show
-p Find me in app/views/tasks/show.html.slim
+h1 タスクの詳細
+
+/ 一覧画面へのリンク
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+table.table.table-hover
+  tbody
+    / タスクのID
+    tr
+      th = Task.human_attribute_name(:id)
+      td = @task.id
+    / タスクの名前
+    tr
+      th = Task.human_attribute_name(:name)
+      td = @task.name
+    / タスクの詳細
+    tr
+      th = Task.human_attribute_name(:description)
+      td = simple_format(h(@task.description), {}, sanitize: false, weapper_tag: "div")
+    / タスクの登録日時
+    tr
+      th = Task.human_attribute_name(:created_at)
+      td = @task.created_at
+    / タスクの更新日時
+    tr
+      th = Task.human_attribute_name(:updated_at)
+      td = @task.updated_at


### PR DESCRIPTION
## What
タスクの詳細表示機能の実装を行う。

## Why
ユーザーが登録したタスクの詳しい内容を確認するため。

実装内容
- index.html.slim内のタスク名称部分に、詳細表示へのリンクを追加。
- tasks_controller.rb内のshowアクションにfindメソッドを利用してアクションを記述。
- show.html.slim内に、ビューの内容記述。
- 各種コメントアウトを追加。