### PR TITLE
タスク編集機能

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,11 +18,18 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:id]) #各タスクに応じた情報をeditへ表示
+  end
+
+  def update
+    task = Task.find(params[:id]) #editで編集した内容をテーブルへ保存する
+    task.update!(task_params)
+    redirect_to task_url, notice: "タスク「#{task.name}」を更新しました。" #編集完了後トップページへリダイレクト
   end
 
   private
   
-  def task_params
+  def task_params #タスク内容のストロングパラメータ
     params.require(:task).permit(:name, :description)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,7 +24,7 @@ class TasksController < ApplicationController
   def update
     task = Task.find(params[:id]) #editで編集した内容をテーブルへ保存する
     task.update!(task_params)
-    redirect_to task_url, notice: "タスク「#{task.name}」を更新しました。" #編集完了後トップページへリダイレクト
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。" #編集完了後トップページへリダイレクト
   end
 
   private

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,10 @@
+/ タスク内容入力部分
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+
+  = f.submit nil, class: 'btn btn-primary' 

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -4,13 +4,5 @@ h1 タスクの編集
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-/ タスク内容編集入力部分
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-
-  = f.submit nil, class: 'btn btn-primary'
+/ 部分テンプレート、_form.html.slimを呼び出し
+= render partial: 'form', loaclas: { task: @task }

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,16 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+/ 一覧へのリンク
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+/ タスク内容編集入力部分
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -21,4 +21,4 @@ table.table.table-hover
           td = link_to task.name, task_path(task)
           td = task.created_at
           td
-            = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr3'
+            = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -12,6 +12,7 @@ table.table.table-hover
     tr
       th = Task.human_attribute_name(:name)
       th = Task.human_attribute_name(:created_at)
+      th
     
     / タスク一覧内容部分
     tbody
@@ -19,3 +20,5 @@ table.table.table-hover
         tr
           td = link_to task.name, task_path(task)
           td = task.created_at
+          td
+            = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr3'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,16 +1,8 @@
 h1 タスクの新規登録
 
 / トップページへの移動
-.nav.justify-cintent-end
+.nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-/ タスク新規登録入力部分
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-
-  = f.submit nil, class: 'btn btn-primary' 
+/ 部分テンプレート、_form.html.slimを呼び出し
+= render partial: 'form', loclas: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -26,3 +26,5 @@ table.table.table-hover
     tr
       th = Task.human_attribute_name(:updated_at)
       td = @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'


### PR DESCRIPTION
## What
タスク内容の編集機能の実装を行う。

## Why
ユーザーがタスクの変更を行えるようにするため。

実装内容
- index.html.slimの各タスク表示部分に編集ボタンを追加。
- show.html.slimに編集ボタンを追加。
- tasks_controller.rbにeditアクションとupdateアクションを追加、内容記述。
- edit.html.slimに編集フォームを記述。
- _form.html.slimを作成。入力フォームを部分テンプレート化。
- new.html.slimとedit.html.slimの入力フォームを部分テンプレートでの呼び出しに記述変更。