### PR TITLE
タスクテーブルオプション追加

### DIFF
--- a/db/migrate/20200630045052_change_tasks_name_not_null.rb
+++ b/db/migrate/20200630045052_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_21_130259) do
+ActiveRecord::Schema.define(version: 2020_06_30_045052) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## What
タスクテーブルの各カラムにオプションを追加する。

## Why
現行のテーブルでは、対応できない例外があるため。

実装内容
- タスクテーブルにnot null制約を追加。