### PR TITLE
タスクモデルバリデーション

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,9 +12,12 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params) #newで入力したタスクをテーブルへ保存する
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。" #登録後トップページへリダイレクト
+    @task = Task.new(task_params) #newで入力したタスクをテーブルへ保存する
+    if @task.save
+      redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。" #登録後トップページへリダイレクト
+    else
+      render :new #保存失敗時にnewへ移動する。
+    end
   end
 
   def edit

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,10 +1,17 @@
 class Task < ApplicationRecord
-  validates :name, presence: true #nameが空の場合、エラーを返す。
-  validates :name, length: { maximum: 30 } #nameが30文字以上の時、エラーを返す
 
-  validate :validate_name_not_including_comma
+  # before_validation :set_nameless_name #nameが空の場合、「名前なし」と自動入力する。
+
+  validates :name, presence: true #nameが空の場合、エラーを返す。
+  validates :name, length: { maximum: 30 } #nameが30文字以上の時、エラーを返す。
+
+  validate :validate_name_not_including_comma #カンマが入っていたら、エラーを返す。
 
   private
+
+  # def set_nameless_name
+  #   self.name = '名前なし' if name.blank?
+  # end
 
   def validate_name_not_including_comma
     errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,3 @@
 class Task < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true #nameが空の場合、エラーを返す。
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,4 @@
 class Task < ApplicationRecord
   validates :name, presence: true #nameが空の場合、エラーを返す。
+  validates :name, length: { maximum: 30 } #nameが30文字以上の時、エラーを返す
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,12 @@
 class Task < ApplicationRecord
   validates :name, presence: true #nameが空の場合、エラーを返す。
   validates :name, length: { maximum: 30 } #nameが30文字以上の時、エラーを返す
+
+  validate :validate_name_not_including_comma
+
+  private
+
+  def validate_name_not_including_comma
+    errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
 end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,3 +1,9 @@
+/ エラーメッセージ表示部分
+- if @task.errors.present?
+  ul#error_explanation
+    - @task.errors.full_messages.each do |message|
+      li = message
+
 / タスク内容入力部分
 = form_with model: @task, local: true do |f|
   .form-group

--- a/db/migrate/20200705125702_change_tasks_name_limit.rb
+++ b/db/migrate/20200705125702_change_tasks_name_limit.rb
@@ -1,0 +1,9 @@
+class ChangeTasksNameLimit < ActiveRecord::Migration[5.2]
+  def up
+    change_column :tasks, :name, :string, limit: 30
+  end
+
+  def down
+    change_column :tasks, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_045052) do
+ActiveRecord::Schema.define(version: 2020_07_05_125702) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name", limit: 30, null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## What
タスクモデルにバリデーションを追加する。

## Why
内容入力時に、不正な値が入力されないようにするため。

実装について
- task.rbに、nameカラムオプション、presence:trueを追加。
- tasks_controller.rbのcreateアクションを変更。
- taskを@taskに変更。
- save!をsaveに変更。
- if文を追加し、保存失敗時はrender:newでnewアクションに遷移先を変更。
- _form.html.slimにエラーメッセージの表示を追加。
- DBのnameカラムに30文字上限のオプションを追加。
- task.rbにnameカラム30文字上限のバリデーションを追加。
- task.rbにnameカラムにカンマが入った場合、エラーを返すバリデーション追加。
- nameが空の場合、「名前なし」を自動入力するコールバックを追加。
※実験実装のため、コメントアウトで無効化。